### PR TITLE
[CHANGE] Migrated to Alliance Auth proxy models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,17 @@ Section Order:
 
 <!-- Your changes go here -->
 
+> [!IMPORTANT]
+>
+> **This version needs Alliance Auth v5.2.0 or newer!**
+>
+> Please make sure to update your Alliance Auth instance **before** you install this
+> version; otherwise, an update to Alliance Auth will be pulled in unsupervised.
+
+### Changed
+
+- Migrated to Alliance Auth proxy models for `Permission`, `User` and `Group`
+
 ## [2.0.1] - 2026-07-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ See [CHANGELOG.md](https://github.com/ppfeufer/aa-mumble-quick-connect/blob/mast
 
 ## Translation Status<a name="translation-status"></a>
 
-[![Translation status](https://weblate.ppfeufer.de/widget/alliance-auth-apps/aa-mumble-quick-connect/multi-auto.svg)](https://weblate.ppfeufer.de/engage/alliance-auth-apps/)
+[![Translation status](https://weblate.ppfeufer.de/widget/alliance-auth-apps/aa-mumble-quick-connect/matrix-auto.svg)](https://weblate.ppfeufer.de/engage/alliance-auth-apps/)
 
 Do you want to help translate this app into your language or improve the existing
 translation? - [Join our team of translators][weblate engage]!

--- a/aa_mumble_quick_connect/templatetags/aa_mumble_quick_connect.py
+++ b/aa_mumble_quick_connect/templatetags/aa_mumble_quick_connect.py
@@ -4,7 +4,9 @@ Template tags for the aa-mumble-quick-connect app.
 
 # Django
 from django import template
-from django.contrib.auth.models import User
+
+# Alliance Auth
+from allianceauth.authentication.models import User
 
 register = template.Library()
 

--- a/aa_mumble_quick_connect/tests/test_access.py
+++ b/aa_mumble_quick_connect/tests/test_access.py
@@ -12,6 +12,7 @@ from django.urls import reverse
 # AA Mumble Quick Connect
 from aa_mumble_quick_connect.tests.utils import (
     create_fake_user,
+    random_id,
     response_content_to_str,
 )
 
@@ -31,7 +32,7 @@ class TestAccess(TestCase):
 
         # User
         cls.user_1001 = create_fake_user(
-            character_id=1001,
+            character_id=random_id(),
             character_name="Jean Luc Picard",
             permissions=[
                 "aa_mumble_quick_connect.basic_access",
@@ -40,19 +41,19 @@ class TestAccess(TestCase):
         )
 
         cls.user_1002 = create_fake_user(
-            character_id=1002,
+            character_id=random_id(),
             character_name="William Riker",
             permissions=["mumble.access_mumble"],
         )
 
         cls.user_1003 = create_fake_user(
-            character_id=1003,
+            character_id=random_id(),
             character_name="Worf",
             permissions=["aa_mumble_quick_connect.basic_access"],
         )
 
         cls.user_1004 = create_fake_user(
-            character_id=1004, character_name="Wesley Crusher"
+            character_id=random_id(), character_name="Wesley Crusher"
         )
 
         cls.html_menu = f"""

--- a/aa_mumble_quick_connect/tests/test_auth_hooks.py
+++ b/aa_mumble_quick_connect/tests/test_auth_hooks.py
@@ -10,7 +10,7 @@ from django.test import TestCase, modify_settings
 from django.urls import reverse
 
 # AA Mumble Quick Connect
-from aa_mumble_quick_connect.tests.utils import create_fake_user
+from aa_mumble_quick_connect.tests.utils import create_fake_user, random_id
 
 
 class TestHooks(TestCase):
@@ -31,7 +31,7 @@ class TestHooks(TestCase):
 
         # User
         cls.user_1001 = create_fake_user(
-            character_id=1001,
+            character_id=random_id(),
             character_name="Jean Luc Picard",
             permissions=[
                 "aa_mumble_quick_connect.basic_access",
@@ -40,7 +40,7 @@ class TestHooks(TestCase):
         )
 
         cls.user_1002 = create_fake_user(
-            character_id=1002, character_name="Wesley Crusher"
+            character_id=random_id(), character_name="Wesley Crusher"
         )
 
         cls.html_menu = f"""

--- a/aa_mumble_quick_connect/tests/test_templatetags.py
+++ b/aa_mumble_quick_connect/tests/test_templatetags.py
@@ -5,8 +5,8 @@ Test the apps' template tags
 # Standard Library
 from unittest.mock import Mock
 
-# Django
-from django.contrib.auth.models import User
+# Alliance Auth
+from allianceauth.authentication.models import User
 
 # AA Mumble Quick Connect
 from aa_mumble_quick_connect.templatetags.aa_mumble_quick_connect import (

--- a/aa_mumble_quick_connect/tests/utils.py
+++ b/aa_mumble_quick_connect/tests/utils.py
@@ -4,13 +4,14 @@ Helper for our tests
 
 # Standard Library
 import re
+import secrets
 
 # Django
-from django.contrib.auth.models import User
 from django.core.handlers.wsgi import WSGIRequest
 from django.template import Context, Template
 
 # Alliance Auth
+from allianceauth.authentication.models import User
 from allianceauth.tests.auth_utils import AuthUtils
 
 
@@ -102,3 +103,16 @@ def create_fake_user(
         user = AuthUtils.add_permissions_to_user(perms=perm_objs, user=user)
 
     return user
+
+
+def random_id(n: int = 26) -> int:
+    """
+    Generate a random ID
+
+    :param n: Length of the ID, optional (default=26 (8 digits in base36))
+    :type n: int
+    :return: A random ID
+    :rtype: int
+    """
+
+    return secrets.randbits(n)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dynamic = [
     "version",
 ]
 dependencies = [
-    "allianceauth>=5,<6",
+    "allianceauth>=5.2,<6",
 ]
 optional-dependencies.tests-allianceauth-latest = [
     "coverage",


### PR DESCRIPTION
## Description

> [!IMPORTANT]
>
> **This version needs Alliance Auth v5.2.0 or newer!**
>
> Please make sure to update your Alliance Auth instance **before** you install this
> version; otherwise, an update to Alliance Auth will be pulled in unsupervised.

### Changed

- Migrated to Alliance Auth proxy models for `Permission`, `User` and `Group`

## Type of Change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
