### PR TITLE
[RELEASE] v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ Section Order:
 
 <!-- Your changes go here -->
 
+## [2.1.0] - 2026-07-09
+
 > [!IMPORTANT]
 >
 > **This version needs Alliance Auth v5.2.0 or newer!**
@@ -226,6 +228,7 @@ Section Order:
 [1.1.3]: https://github.com/ppfeufer/aa-mumble-quick-connect/compare/v1.1.2...v1.1.3 "v1.1.3"
 [2.0.0]: https://github.com/ppfeufer/aa-mumble-quick-connect/compare/v1.1.3...v2.0.0 "v2.0.0"
 [2.0.1]: https://github.com/ppfeufer/aa-mumble-quick-connect/compare/v2.0.0...v2.0.1 "v2.0.1"
-[in development]: https://github.com/ppfeufer/aa-mumble-quick-connect/compare/v2.0.1...HEAD "In Development"
+[2.1.0]: https://github.com/ppfeufer/aa-mumble-quick-connect/compare/v2.0.1...v2.1.0 "v2.1.0"
+[in development]: https://github.com/ppfeufer/aa-mumble-quick-connect/compare/v2.1.0...HEAD "In Development"
 [keep a changelog]: http://keepachangelog.com/ "Keep a Changelog"
 [semantic versioning]: http://semver.org/ "Semantic Versioning"

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ ______________________________________________________________________
 Install the app using pip:
 
 ```shell
-pip install aa-mumble-quick-connect==2.0.1
+pip install aa-mumble-quick-connect==2.1.0
 ```
 
 #### Step 2: Update Your AA Settings<a name="step-2-update-your-aa-settings"></a>
@@ -91,7 +91,7 @@ python manage.py collectstatic --noinput
 Add the app to your `conf/requirements.txt`:
 
 ```text
-aa-mumble-quick-connect==2.0.1
+aa-mumble-quick-connect==2.1.0
 ```
 
 #### Step 2: Update Your AA Settings<a name="step-2-update-your-aa-settings-1"></a>

--- a/aa_mumble_quick_connect/__init__.py
+++ b/aa_mumble_quick_connect/__init__.py
@@ -5,6 +5,6 @@ Initialize the app
 # Django
 from django.utils.translation import gettext_lazy as _
 
-__version__ = "2.0.1"
+__version__ = "2.1.0"
 __title__ = "Mumble Quick Connect"
 __title_translated__ = _("Mumble Quick Connect")


### PR DESCRIPTION
## [2.1.0] - 2026-07-09

> [!IMPORTANT]
> 
> **This version needs Alliance Auth v5.2.0 or newer!**
> 
> Please make sure to update your Alliance Auth instance **before** you install this
> version; otherwise, an update to Alliance Auth will be pulled in unsupervised.

### Changed

- Migrated to Alliance Auth proxy models for `Permission`, `User` and `Group`
